### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,17 @@ os:
   - linux
   - osx
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - node
   - '7'
   - '6'
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'
+  - '12'
+  - '10'
 matrix:
   allow_failures: []
   fast_finish: true


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.
